### PR TITLE
fix: add constraints for create Customer

### DIFF
--- a/src/DTO/Customer/CreateCustomer.php
+++ b/src/DTO/Customer/CreateCustomer.php
@@ -41,7 +41,7 @@ class CreateCustomer
 
     private Address $address;
 
-    public function getGender(): ?string
+    public function getGender(): string
     {
         return $this->gender;
     }
@@ -53,7 +53,7 @@ class CreateCustomer
         return $this;
     }
 
-    public function getFirstName(): ?string
+    public function getFirstName(): string
     {
         return $this->firstName;
     }
@@ -65,7 +65,7 @@ class CreateCustomer
         return $this;
     }
 
-    public function getLastName(): ?string
+    public function getLastName(): string
     {
         return $this->lastName;
     }
@@ -77,7 +77,7 @@ class CreateCustomer
         return $this;
     }
 
-    public function getAddress(): ?Address
+    public function getAddress(): Address
     {
         return $this->address;
     }

--- a/src/Form/AddressType.php
+++ b/src/Form/AddressType.php
@@ -5,6 +5,7 @@ namespace App\Form;
 use App\DTO\Address\Address;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Validator\Constraints\Regex;
 use Symfony\Component\Validator\Constraints\Length;
 use Symfony\Component\Validator\Constraints\NotBlank;
 use Symfony\Component\OptionsResolver\OptionsResolver;
@@ -37,6 +38,7 @@ class AddressType extends AbstractType
                 ],
                 'constraints' => [
                     new NotBlank(),
+                    new Regex('#^[A-Za-z]+$#', "Only letters are valid characters"),
                     new Length([
                         'min' => 4,
                         'max' => 100,
@@ -52,6 +54,7 @@ class AddressType extends AbstractType
                 ],
                 'constraints' => [
                     new NotBlank(),
+                    new Regex('#^[-0-9]+$#', "Only numbers are valid characters"),
                     new Length([
                         'min' => 5,
                         'max' => 10,

--- a/src/Form/CreateCustomerType.php
+++ b/src/Form/CreateCustomerType.php
@@ -11,6 +11,7 @@ use Symfony\Component\Validator\Constraints\NotBlank;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Validator\Constraints\Email;
+use Symfony\Component\Validator\Constraints\Regex;
 
 class CreateCustomerType extends AbstractType
 {
@@ -23,6 +24,7 @@ class CreateCustomerType extends AbstractType
                     'description' => 'Gender: Mr., Ms. or Miss.',
                 ],
                 'constraints' => [
+                    new NotBlank(),
                     new Choice(
                         ['Mr.', 'Ms.', 'Miss'],
                         null,
@@ -41,6 +43,7 @@ class CreateCustomerType extends AbstractType
                 ],
                 'constraints' => [
                     new NotBlank(),
+                    new Regex('#^[A-Za-z]+$#', "Only letters are valid characters"),
                     new Length([
                         'min' => 2,
                         'max' => 100,
@@ -55,6 +58,8 @@ class CreateCustomerType extends AbstractType
                     'description' => 'Last name.',
                 ],
                 'constraints' => [
+                    new NotBlank(),
+                    new Regex('#^[A-Za-z]+$#', "Only letters are valid characters"),
                     new Length([
                         'min' => 2,
                         'max' => 100,
@@ -69,6 +74,7 @@ class CreateCustomerType extends AbstractType
                     'description' => 'Email address.',
                 ],
                 'constraints' => [
+                    new NotBlank(),
                     new Length([
                         'min' => 10,
                         'max' => 255,
@@ -85,6 +91,7 @@ class CreateCustomerType extends AbstractType
                 ],
                 'constraints' => [
                     new NotBlank(),
+                    new Regex('#^[0-9]+$#', "Only numbers are valid characters"),
                     new Length([
                         'min' => 10,
                         'max' => 20,

--- a/tests/Controller/CustomerControllerTest.php
+++ b/tests/Controller/CustomerControllerTest.php
@@ -96,7 +96,7 @@ class CustomerControllerTest extends AppWebTestCase
             'gender' => 'Mr.',
             'firstName' => 'Chandler',
             'lastName' => 'Bing',
-            'phoneNumber' => '+14409630378',
+            'phoneNumber' => '01409630378',
             'email' => 'chandler.bing@example.com',
             'address' => [
                 'address' => '774 Schmeler Vista Suite 270',


### PR DESCRIPTION
### Problem
A server error is displayed when not submitting `firstname` or `lastname` whereas it displays an error message when not submitting email or phone number.

### Cause
The server error is displayed because it passes null to setter method instead of string:

```php
    public function setFirstName(string $firstName): self
    {
        $this->firstName = $firstName;

        return $this;
    }
```

### Solution
We could allow null for the parameter:
```php
    public function setFirstName(?string $firstName): self
```

But instead, we have added `NotBlank` constraint to properties for 2 reasons:
- If the value is null or blank, the setter method is not executed.
- The NotBlank constraint should be added in the first place.